### PR TITLE
Change the port number in ContainerPort

### DIFF
--- a/bab-07c-kudemo-api-deployment.yaml
+++ b/bab-07c-kudemo-api-deployment.yaml
@@ -16,4 +16,4 @@ spec:
       - name: api
         image: ngoprek/kudemo-todo-api
         ports:
-        - containerPort: 3000
+        - containerPort: 8080

--- a/bab-07f-kudemo-api-deployment.yaml
+++ b/bab-07f-kudemo-api-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       - name: api
         image: ngoprek/kudemo-todo-api
         ports:
-        - containerPort: 3000
+        - containerPort: 8080
        # daftar environment variabel didefinisikan di sini
         env:
         - name: POSTGRES_ENABLED

--- a/bab-10a-kudemo-todo-ui-deployment.yaml
+++ b/bab-10a-kudemo-todo-ui-deployment.yaml
@@ -16,4 +16,4 @@ spec:
       - name: kudemo-todo-ui
         image: ngoprek/kudemo-todo-ui
         ports:
-        - containerPort: 8080
+        - containerPort: 80


### PR DESCRIPTION
The ContainerPort  should be `8080` for `todo-api` and `80` for `todo-ui` as defined on `docker-compose.yaml`.