### PR TITLE
Update nginx-ingress controller annotations and pathType

### DIFF
--- a/bab-10a-ingress-service.yaml
+++ b/bab-10a-ingress-service.yaml
@@ -10,14 +10,14 @@ spec:
   - http:
       paths:
       - path: /?(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: kudemo-todo-ui-cluster-ip-service
             port:
               number: 80
       - path: /api/?(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: api-load-balancer-service

--- a/bab-10a-ingress-service.yaml
+++ b/bab-10a-ingress-service.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: ingress-service
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:


### PR DESCRIPTION
because we're having this WARNING:
```
$ kubectl apply -f bab-10a-ingress-service.yaml
Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

and also:
```
Warning: path /?(.*) cannot be used with pathType Prefix
Warning: path /api/?(.*) cannot be used with pathType Prefix
```